### PR TITLE
Use Long Polling

### DIFF
--- a/src/main/java/de/jojii/matrixclientserver/Bot/Syncee.java
+++ b/src/main/java/de/jojii/matrixclientserver/Bot/Syncee.java
@@ -15,6 +15,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Syncee {
+
+    private static final int LONG_POLLING_TIMEOUT = 40000;
+
     private Client c;
     private HttpHelper httpHelper;
     private List<RoomEventsCallback> roomEvents = new ArrayList<>();
@@ -77,7 +80,7 @@ public class Syncee {
     private void runEventListener(String filterID) {
         if (eventListenerThread == null) {
             eventListenerThread = new Thread(() -> {
-                String baseurl = HttpHelper.URLs.sync + "?access_token=" + c.getLoginData().getAccess_token() + "&filter=" + filterID;
+                String baseurl = HttpHelper.URLs.sync + "?access_token=" + c.getLoginData().getAccess_token() + "&filter=" + filterID + "&timeout=" + LONG_POLLING_TIMEOUT;
                 String nextURL = "";
                 try {
                     if(!new File(Files.sync_next_batch).exists()){

--- a/src/main/java/de/jojii/matrixclientserver/Networking/HttpHelper.java
+++ b/src/main/java/de/jojii/matrixclientserver/Networking/HttpHelper.java
@@ -41,6 +41,7 @@ public class HttpHelper {
         HttpURLConnection http = (HttpURLConnection)con;
         http.setRequestMethod(requestMethod);
         http.setDoOutput(true);
+        http.setReadTimeout(60000);
 
         if(data != null){
             int length = data.toString().length();


### PR DESCRIPTION
This uses long polling method by default. Sync request specifies a timeout of 40 seconds. In this implementation there is no way to change that timeout but I think it has no negative effects.

Reason: Without the timeout it's spamming my homeserver every 200ms. Now it only does new requests when an update arrives or the timeout of 40s runs out.

I already use this for a bot and wanted to make this available to others :)